### PR TITLE
Jenkins build 390 errors

### DIFF
--- a/requests/gemini_fusions@6e3d2bd01a96.yml
+++ b/requests/gemini_fusions@6e3d2bd01a96.yml
@@ -1,0 +1,7 @@
+tools:
+- name: gemini_fusions
+  owner: iuc
+  revisions:
+  - 6e3d2bd01a96
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
Failed to install gemini_fusions. Tests failed on  https://galaxy-cat.genome.edu.au.

Storing log file in: tmp/test_log.txt
Executing test 'toolshed.g2.bx.psu.edu/repos/iuc/gemini_fusions/gemini_fusions/0.20.1-0'
Test 'toolshed.g2.bx.psu.edu/repos/iuc/gemini_fusions/gemini_fusions/0.20.1-0' failed
Traceback (most recent call last):
  File "/var/lib/jenkins/jobs/galaxy tool automation (work in progress)/.venv/local/lib/python2.7/site-packages/ephemeris/shed_tools.py", line 350, in run_test
    register_job_data=register, quiet=True, test_history=test_history,
  File "/var/lib/jenkins/jobs/galaxy tool automation (work in progress)/.venv/local/lib/python2.7/site-packages/galaxy/tool_util/verify/interactor.py", line 774, in verify_tool
    raise e
RunToolException: Error creating a job for these tool inputs - parameter 'annotation_databases': an invalid option (None) was selected, please verify
Report written to '/var/lib/jenkins/galaxy_tool_automation/20200124051544_staging_test.json'
Passed tool tests (0): []
Failed tool tests (1): [u'toolshed.g2.bx.psu.edu/repos/iuc/gemini_fusions/gemini_fusions/0.20.1-0']
Total tool test time: 0:00:07.019813