### PR TITLE
Jenkins build  errors

### DIFF
--- a/requests/gemini_interactions@7028ca3cac1c.yml
+++ b/requests/gemini_interactions@7028ca3cac1c.yml
@@ -1,0 +1,7 @@
+tools:
+- name: gemini_interactions
+  owner: iuc
+  revisions:
+  - 7028ca3cac1c
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/gemini_load@b2c25142267e.yml
+++ b/requests/gemini_load@b2c25142267e.yml
@@ -1,0 +1,7 @@
+tools:
+- name: gemini_load
+  owner: iuc
+  revisions:
+  - b2c25142267e
+  tool_panel_section_label: Gemini Tools
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
Failed to install gemini_interactions. Tests failed on  https://galaxy-cat.genome.edu.au.

Storing log file in: tmp/test_log.txt
Executing test 'toolshed.g2.bx.psu.edu/repos/iuc/gemini_interactions/gemini_interactions/0.20.1-0'
Executing test 'toolshed.g2.bx.psu.edu/repos/iuc/gemini_interactions/gemini_interactions/0.20.1-1'
Test 'toolshed.g2.bx.psu.edu/repos/iuc/gemini_interactions/gemini_interactions/0.20.1-1' failed
Traceback (most recent call last):
  File "/Users/catherine/dev/usegalaxy-au-tools/.venv/lib/python2.7/site-packages/ephemeris/shed_tools.py", line 350, in run_test
    register_job_data=register, quiet=True, test_history=test_history,
  File "/Users/catherine/dev/usegalaxy-au-tools/.venv/lib/python2.7/site-packages/galaxy/tool_util/verify/interactor.py", line 774, in verify_tool
    raise e
RunToolException: Error creating a job for these tool inputs - parameter 'annotation_databases': an invalid option (None) was selected, please verify
Test 'toolshed.g2.bx.psu.edu/repos/iuc/gemini_interactions/gemini_interactions/0.20.1-0' failed
Traceback (most recent call last):
  File "/Users/catherine/dev/usegalaxy-au-tools/.venv/lib/python2.7/site-packages/ephemeris/shed_tools.py", line 350, in run_test
    register_job_data=register, quiet=True, test_history=test_history,
  File "/Users/catherine/dev/usegalaxy-au-tools/.venv/lib/python2.7/site-packages/galaxy/tool_util/verify/interactor.py", line 774, in verify_tool
    raise e
RunToolException: Error creating a job for these tool inputs - parameter 'annotation_databases': an invalid option (None) was selected, please verify
Report written to '/Users/catherine/dev/usegalaxy-au-tools/logs/20200124180208_staging_test.json'
Passed tool tests (0): []
Failed tool tests (2): [u'toolshed.g2.bx.psu.edu/repos/iuc/gemini_interactions/gemini_interactions/0.20.1-1', u'toolshed.g2.bx.psu.edu/repos/iuc/gemini_interactions/gemini_interactions/0.20.1-0']
Total tool test time: 0:00:14.352604



Failed to install gemini_load. Tests failed on  https://galaxy-cat.genome.edu.au.

Storing log file in: tmp/test_log.txt
Executing test 'toolshed.g2.bx.psu.edu/repos/iuc/gemini_load/gemini_load/0.20.1+galaxy1-0'
Executing test 'toolshed.g2.bx.psu.edu/repos/iuc/gemini_load/gemini_load/0.20.1+galaxy1-1'
Executing test 'toolshed.g2.bx.psu.edu/repos/iuc/gemini_load/gemini_load/0.20.1+galaxy1-2'
Executing test 'toolshed.g2.bx.psu.edu/repos/iuc/gemini_load/gemini_load/0.20.1+galaxy1-3'
Test 'toolshed.g2.bx.psu.edu/repos/iuc/gemini_load/gemini_load/0.20.1+galaxy1-0' failed
Traceback (most recent call last):
  File "/Users/catherine/dev/usegalaxy-au-tools/.venv/lib/python2.7/site-packages/ephemeris/shed_tools.py", line 350, in run_test
    register_job_data=register, quiet=True, test_history=test_history,
  File "/Users/catherine/dev/usegalaxy-au-tools/.venv/lib/python2.7/site-packages/galaxy/tool_util/verify/interactor.py", line 792, in verify_tool
    raise e
AttributeError: 'NoneType' object has no attribute 'find'
Test 'toolshed.g2.bx.psu.edu/repos/iuc/gemini_load/gemini_load/0.20.1+galaxy1-2' failed
Traceback (most recent call last):
  File "/Users/catherine/dev/usegalaxy-au-tools/.venv/lib/python2.7/site-packages/ephemeris/shed_tools.py", line 350, in run_test
    register_job_data=register, quiet=True, test_history=test_history,
  File "/Users/catherine/dev/usegalaxy-au-tools/.venv/lib/python2.7/site-packages/galaxy/tool_util/verify/interactor.py", line 792, in verify_tool
    raise e
AttributeError: 'NoneType' object has no attribute 'find'
Test 'toolshed.g2.bx.psu.edu/repos/iuc/gemini_load/gemini_load/0.20.1+galaxy1-1' failed
Traceback (most recent call last):
  File "/Users/catherine/dev/usegalaxy-au-tools/.venv/lib/python2.7/site-packages/ephemeris/shed_tools.py", line 350, in run_test
    register_job_data=register, quiet=True, test_history=test_history,
  File "/Users/catherine/dev/usegalaxy-au-tools/.venv/lib/python2.7/site-packages/galaxy/tool_util/verify/interactor.py", line 774, in verify_tool
    raise e
RunToolException: Error creating a job for these tool inputs - parameter 'annotation_databases': requires a value, but no legal values defined
Test 'toolshed.g2.bx.psu.edu/repos/iuc/gemini_load/gemini_load/0.20.1+galaxy1-3' failed
Traceback (most recent call last):
  File "/Users/catherine/dev/usegalaxy-au-tools/.venv/lib/python2.7/site-packages/ephemeris/shed_tools.py", line 350, in run_test
    register_job_data=register, quiet=True, test_history=test_history,
  File "/Users/catherine/dev/usegalaxy-au-tools/.venv/lib/python2.7/site-packages/galaxy/tool_util/verify/interactor.py", line 774, in verify_tool
    raise e
RunToolException: Error creating a job for these tool inputs - parameter 'annotation_databases': requires a value, but no legal values defined
Report written to '/Users/catherine/dev/usegalaxy-au-tools/logs/20200124180208_staging_test.json'
Passed tool tests (0): []
Failed tool tests (4): [u'toolshed.g2.bx.psu.edu/repos/iuc/gemini_load/gemini_load/0.20.1+galaxy1-0', u'toolshed.g2.bx.psu.edu/repos/iuc/gemini_load/gemini_load/0.20.1+galaxy1-2', u'toolshed.g2.bx.psu.edu/repos/iuc/gemini_load/gemini_load/0.20.1+galaxy1-1', u'toolshed.g2.bx.psu.edu/repos/iuc/gemini_load/gemini_load/0.20.1+galaxy1-3']
Total tool test time: 0:00:53.554041