### PR TITLE
Jenkins build 502 errors

### DIFF
--- a/requests/data_manager_bowtie2_index_builder@83da94c0e4a6.yml
+++ b/requests/data_manager_bowtie2_index_builder@83da94c0e4a6.yml
@@ -1,0 +1,7 @@
+tools:
+- name: data_manager_bowtie2_index_builder
+  owner: devteam
+  revisions:
+  - 83da94c0e4a6
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/data_manager_bwa_mem_index_builder@46066df8813d.yml
+++ b/requests/data_manager_bwa_mem_index_builder@46066df8813d.yml
@@ -1,0 +1,7 @@
+tools:
+- name: data_manager_bwa_mem_index_builder
+  owner: devteam
+  revisions:
+  - 46066df8813d
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/data_manager_fetch_genome_dbkeys_all_fasta@b1bc53e9bbc5.yml
+++ b/requests/data_manager_fetch_genome_dbkeys_all_fasta@b1bc53e9bbc5.yml
@@ -1,0 +1,7 @@
+tools:
+- name: data_manager_fetch_genome_dbkeys_all_fasta
+  owner: devteam
+  revisions:
+  - b1bc53e9bbc5
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/data_manager_gatk_picard_index_builder@b31f1fcb203c.yml
+++ b/requests/data_manager_gatk_picard_index_builder@b31f1fcb203c.yml
@@ -1,0 +1,7 @@
+tools:
+- name: data_manager_gatk_picard_index_builder
+  owner: devteam
+  revisions:
+  - b31f1fcb203c
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/data_manager_hisat2_index_builder@d210e1f185bd.yml
+++ b/requests/data_manager_hisat2_index_builder@d210e1f185bd.yml
@@ -1,0 +1,7 @@
+tools:
+- name: data_manager_hisat2_index_builder
+  owner: iuc
+  revisions:
+  - d210e1f185bd
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/data_manager_kallisto_index_builder@6843a0db2da0.yml
+++ b/requests/data_manager_kallisto_index_builder@6843a0db2da0.yml
@@ -1,0 +1,7 @@
+tools:
+- name: data_manager_kallisto_index_builder
+  owner: iuc
+  revisions:
+  - 6843a0db2da0
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/data_manager_sam_fasta_index_builder@1865e693d8b2.yml
+++ b/requests/data_manager_sam_fasta_index_builder@1865e693d8b2.yml
@@ -1,0 +1,7 @@
+tools:
+- name: data_manager_sam_fasta_index_builder
+  owner: devteam
+  revisions:
+  - 1865e693d8b2
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/data_manager_snpeff@a6400027d849.yml
+++ b/requests/data_manager_snpeff@a6400027d849.yml
@@ -1,7 +1,5 @@
 tools:
 - name: data_manager_snpeff
   owner: iuc
-  revisions:
-  - a6400027d849
   tool_panel_section_label: None
   tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/data_manager_snpeff@a6400027d849.yml
+++ b/requests/data_manager_snpeff@a6400027d849.yml
@@ -1,0 +1,7 @@
+tools:
+- name: data_manager_snpeff
+  owner: iuc
+  revisions:
+  - a6400027d849
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu

--- a/requests/rnachipintegrator@b695071de766.yml
+++ b/requests/rnachipintegrator@b695071de766.yml
@@ -1,0 +1,7 @@
+tools:
+- name: rnachipintegrator
+  owner: pjbriggs
+  revisions:
+  - b695071de766
+  tool_panel_section_label: None
+  tool_shed_url: toolshed.g2.bx.psu.edu


### PR DESCRIPTION
Failed to install data_manager_bowtie2_index_builder on https://cat-dev.genome.edu.au

Storing log file in: tmp/requests/install_log.txt
(1/1) Installing repository data_manager_bowtie2_index_builder from devteam to section "None" at revision 83da94c0e4a6 (TRT: 0:00:00.577694)
	* Error installing a repository (after 0:00:12.396012 seconds)! Name: data_manager_bowtie2_index_builder,owner: devteam, revision: 83da94c0e4a6, error: {"err_msg": "Uncaught exception in exposed API method:", "err_code": 0}
Installed repositories (0): []
Skipped repositories (0): []
Errored repositories (1): [('data_manager_bowtie2_index_builder', '83da94c0e4a6')]
All repositories have been installed.
Total run time: 0:00:12.974460



Failed to install data_manager_bwa_mem_index_builder on https://cat-dev.genome.edu.au

Storing log file in: tmp/requests/install_log.txt
(1/1) Installing repository data_manager_bwa_mem_index_builder from devteam to section "None" at revision 46066df8813d (TRT: 0:00:00.528341)
	* Error installing a repository (after 0:00:11.102992 seconds)! Name: data_manager_bwa_mem_index_builder,owner: devteam, revision: 46066df8813d, error: {"err_msg": "Uncaught exception in exposed API method:", "err_code": 0}
Installed repositories (0): []
Skipped repositories (0): []
Errored repositories (1): [('data_manager_bwa_mem_index_builder', '46066df8813d')]
All repositories have been installed.
Total run time: 0:00:11.632138



Failed to install data_manager_fetch_genome_dbkeys_all_fasta on https://cat-dev.genome.edu.au

Storing log file in: tmp/requests/install_log.txt
(1/1) Installing repository data_manager_fetch_genome_dbkeys_all_fasta from devteam to section "None" at revision b1bc53e9bbc5 (TRT: 0:00:00.527293)
	* Error installing a repository (after 0:00:10.787978 seconds)! Name: data_manager_fetch_genome_dbkeys_all_fasta,owner: devteam, revision: b1bc53e9bbc5, error: {"err_msg": "Uncaught exception in exposed API method:", "err_code": 0}
Installed repositories (0): []
Skipped repositories (0): []
Errored repositories (1): [('data_manager_fetch_genome_dbkeys_all_fasta', 'b1bc53e9bbc5')]
All repositories have been installed.
Total run time: 0:00:11.316135



Failed to install data_manager_gatk_picard_index_builder on https://cat-dev.genome.edu.au

Storing log file in: tmp/requests/install_log.txt
(1/1) Installing repository data_manager_gatk_picard_index_builder from devteam to section "None" at revision b31f1fcb203c (TRT: 0:00:00.550287)
	* Error installing a repository (after 0:00:31.634626 seconds)! Name: data_manager_gatk_picard_index_builder,owner: devteam, revision: b31f1fcb203c, error: {"err_msg": "Uncaught exception in exposed API method:", "err_code": 0}
Installed repositories (0): []
Skipped repositories (0): []
Errored repositories (1): [('data_manager_gatk_picard_index_builder', 'b31f1fcb203c')]
All repositories have been installed.
Total run time: 0:00:32.185909



Failed to install data_manager_hisat2_index_builder on https://cat-dev.genome.edu.au

Storing log file in: tmp/requests/install_log.txt
(1/1) Installing repository data_manager_hisat2_index_builder from iuc to section "None" at revision d210e1f185bd (TRT: 0:00:00.529923)
	* Error installing a repository (after 0:00:11.798162 seconds)! Name: data_manager_hisat2_index_builder,owner: iuc, revision: d210e1f185bd, error: {"err_msg": "Uncaught exception in exposed API method:", "err_code": 0}
Installed repositories (0): []
Skipped repositories (0): []
Errored repositories (1): [('data_manager_hisat2_index_builder', 'd210e1f185bd')]
All repositories have been installed.
Total run time: 0:00:12.329076



Failed to install data_manager_kallisto_index_builder on https://cat-dev.genome.edu.au

Storing log file in: tmp/requests/install_log.txt
(1/1) Installing repository data_manager_kallisto_index_builder from iuc to section "None" at revision 6843a0db2da0 (TRT: 0:00:00.584556)
	* Error installing a repository (after 0:00:10.556983 seconds)! Name: data_manager_kallisto_index_builder,owner: iuc, revision: 6843a0db2da0, error: {"err_msg": "Uncaught exception in exposed API method:", "err_code": 0}
Installed repositories (0): []
Skipped repositories (0): []
Errored repositories (1): [('data_manager_kallisto_index_builder', '6843a0db2da0')]
All repositories have been installed.
Total run time: 0:00:11.142415



Failed to install data_manager_sam_fasta_index_builder on https://cat-dev.genome.edu.au

Storing log file in: tmp/requests/install_log.txt
(1/1) Installing repository data_manager_sam_fasta_index_builder from devteam to section "None" at revision 1865e693d8b2 (TRT: 0:00:01.087785)
	* Error installing a repository (after 0:00:12.398164 seconds)! Name: data_manager_sam_fasta_index_builder,owner: devteam, revision: 1865e693d8b2, error: {"err_msg": "Uncaught exception in exposed API method:", "err_code": 0}
Installed repositories (0): []
Skipped repositories (0): []
Errored repositories (1): [('data_manager_sam_fasta_index_builder', '1865e693d8b2')]
All repositories have been installed.
Total run time: 0:00:13.486663



Failed to install data_manager_snpeff on https://cat-dev.genome.edu.au

Storing log file in: tmp/requests/install_log.txt
(1/1) Installing repository data_manager_snpeff from iuc to section "None" at revision a6400027d849 (TRT: 0:00:00.569674)
Timeout during install of data_manager_snpeff, extending wait to 1h
	* Error installing a repository (after 1:01:00.163999 seconds)! Name: data_manager_snpeff,owner: iuc, revision: a6400027d849, error: <html>
<head><title>504 Gateway Time-out</title></head>
<body bgcolor="white">
<center><h1>504 Gateway Time-out</h1></center>
<hr><center>nginx/1.14.0 (Ubuntu)</center>
</body>
</html>

Installed repositories (0): []
Skipped repositories (0): []
Errored repositories (1): [('data_manager_snpeff', 'a6400027d849')]
All repositories have been installed.
Total run time: 1:01:00.734777



Failed to install rnachipintegrator on https://galaxy-cat.genome.edu.au

Storing log file in: tmp/requests/test_log.txt
Executing test 'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_wrapper/1.0.3.1-0'
Executing test 'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_wrapper/1.0.3.1-1'
Executing test 'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_wrapper/1.0.3.1-2'
Executing test 'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_wrapper/1.0.3.1-3'
Test 'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_wrapper/1.0.3.1-0' passed
Executing test 'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_wrapper/1.0.3.1-4'
Test 'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_wrapper/1.0.3.1-3' passed
Executing test 'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_wrapper/1.0.3.1-5'
Test 'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_wrapper/1.0.3.1-2' passed
Executing test 'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_canonical_genes/1.0.3.1-0'
Test 'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_wrapper/1.0.3.1-1' passed
Executing test 'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_canonical_genes/1.0.3.1-1'
Test 'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_canonical_genes/1.0.3.1-0' failed
Traceback (most recent call last):
  File "/var/lib/jenkins/jobs/galaxy tool automation (work in progress)/.venv/local/lib/python2.7/site-packages/ephemeris/shed_tools.py", line 350, in run_test
    register_job_data=register, quiet=True, test_history=test_history,
  File "/var/lib/jenkins/jobs/galaxy tool automation (work in progress)/.venv/local/lib/python2.7/site-packages/galaxy/tool_util/verify/interactor.py", line 774, in verify_tool
    raise e
RunToolException: Error creating a job for these tool inputs - parameter 'canonical_genes': requires a value, but no legal values defined
Executing test 'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_canonical_genes/1.0.3.1-2'
Test 'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_canonical_genes/1.0.3.1-1' failed
Traceback (most recent call last):
  File "/var/lib/jenkins/jobs/galaxy tool automation (work in progress)/.venv/local/lib/python2.7/site-packages/ephemeris/shed_tools.py", line 350, in run_test
    register_job_data=register, quiet=True, test_history=test_history,
  File "/var/lib/jenkins/jobs/galaxy tool automation (work in progress)/.venv/local/lib/python2.7/site-packages/galaxy/tool_util/verify/interactor.py", line 789, in verify_tool
    raise e
JobOutputsError: Job in error state.
Job in error state.
Job in error state.
Job in error state.
Test 'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_canonical_genes/1.0.3.1-2' failed
Traceback (most recent call last):
  File "/var/lib/jenkins/jobs/galaxy tool automation (work in progress)/.venv/local/lib/python2.7/site-packages/ephemeris/shed_tools.py", line 350, in run_test
    register_job_data=register, quiet=True, test_history=test_history,
  File "/var/lib/jenkins/jobs/galaxy tool automation (work in progress)/.venv/local/lib/python2.7/site-packages/galaxy/tool_util/verify/interactor.py", line 774, in verify_tool
    raise e
RunToolException: Error creating a job for these tool inputs - parameter 'canonical_genes': requires a value, but no legal values defined
Test 'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_wrapper/1.0.3.1-4' passed
Test 'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_wrapper/1.0.3.1-5' passed
Report written to '/var/lib/jenkins/galaxy_tool_automation/502_staging_test.json'
Passed tool tests (6): [u'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_wrapper/1.0.3.1-0', u'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_wrapper/1.0.3.1-3', u'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_wrapper/1.0.3.1-2', u'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_wrapper/1.0.3.1-1', u'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_wrapper/1.0.3.1-4', u'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_wrapper/1.0.3.1-5']
Failed tool tests (3): [u'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_canonical_genes/1.0.3.1-0', u'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_canonical_genes/1.0.3.1-1', u'toolshed.g2.bx.psu.edu/repos/pjbriggs/rnachipintegrator/rnachipintegrator_canonical_genes/1.0.3.1-2']
Total tool test time: 0:02:19.651579